### PR TITLE
Update versions

### DIFF
--- a/lib/rack/singleshot.rb
+++ b/lib/rack/singleshot.rb
@@ -1,5 +1,6 @@
 require 'rack'
 require 'http/parser'
+require 'uri'
 
 module Rack
   module Handler
@@ -60,9 +61,10 @@ module Rack
       end
 
       def request_parts_from(parser)
+        uri = URI.parse(parser.request_url)
         [parser.http_method,
-         parser.request_path,
-         parser.query_string,
+         uri.path,
+         uri.query || "",
          parser.http_version.join('.'),
          parse_headers(parser.headers)]
       end

--- a/lib/rack/singleshot.rb
+++ b/lib/rack/singleshot.rb
@@ -54,6 +54,7 @@ module Rack
 
           break if finished
         end
+        body.rewind
 
         return request_parts_from(parser) << body
       rescue EOFError

--- a/spec/singleshot_spec.rb
+++ b/spec/singleshot_spec.rb
@@ -37,6 +37,10 @@ RESPONSE
       get '/params' do
         params.inspect
       end
+
+      post '/' do
+        params.inspect
+      end
     end
 
     before(:each) do
@@ -71,6 +75,20 @@ REQUEST
       @server.run
 
       expect(@out.read).to include('{"foo"=>"bar", "baz"=>"bang"}')
+    end
+    it 'can handle a POST request' do
+      @in << <<-REQUEST.gsub("\n", "\r\n")
+POST / HTTP/1.1
+Server-Name: localhost
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 7
+
+foo=bar
+REQUEST
+
+      @server.run
+
+      expect(@out.read).to include('{"foo"=>"bar"}')
     end
   end
 end

--- a/spec/singleshot_spec.rb
+++ b/spec/singleshot_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rack::Handler::SingleShot do
+RSpec.describe Rack::Handler::SingleShot do
   before(:each) do
     @stdin, @in   = IO.pipe
     @out, @stdout = IO.pipe
@@ -8,7 +8,7 @@ describe Rack::Handler::SingleShot do
     @app = Rack::Lint.new(lambda {|env| [200, {'Content-Type' => 'text/plain'}, []] })
     @server = Rack::Handler::SingleShot.new(@app, @stdin, @stdout)
 
-    @server.stub(:exit)
+    allow(@server).to receive(:exit)
   end
 
   it 'can handle a simple request' do
@@ -20,7 +20,7 @@ REQUEST
 
     @server.run
 
-    @out.read.should == <<-RESPONSE.gsub("\n", "\r\n")
+    expect(@out.read).to eq <<-RESPONSE.gsub("\n", "\r\n")
 HTTP/1.1 200 OK
 Content-Type: text/plain
 
@@ -46,7 +46,7 @@ RESPONSE
       @app = Rack::Lint.new(App.new)
       @server = Rack::Handler::SingleShot.new(@app, @stdin, @stdout)
 
-      @server.stub(:exit)
+      allow(@server).to receive(:exit)
     end
 
     it 'can handle a sinatra request' do
@@ -58,7 +58,7 @@ REQUEST
 
       @server.run
 
-      @out.read.should =~ /response body\Z/
+      expect(@out.read).to match(/response body\Z/)
     end
 
     it 'supports query string parameters' do
@@ -70,7 +70,7 @@ REQUEST
 
       @server.run
 
-      @out.read.should include('{"foo"=>"bar", "baz"=>"bang"}')
+      expect(@out.read).to include('{"foo"=>"bar", "baz"=>"bang"}')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,5 @@ require 'rack/singleshot'
 require 'sinatra'
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
 end


### PR DESCRIPTION
This pull request updates the gem to use the latest version of RSpec without deprecation warnings, and also to work with the current release of http_parser.rb (0.6.0).  Hope its helpful!
